### PR TITLE
feat(datashed): Change order of `doctype` dtype

### DIFF
--- a/crates/datashed-cli/src/doctype.rs
+++ b/crates/datashed-cli/src/doctype.rs
@@ -25,9 +25,7 @@ pub(crate) const DOCTYPES: [&str; 30] = [
     "magister-thesis",
     "master-thesis",
     "musical-notation",
-    "none",
     "nonfiction-book",
-    "other",
     "policy-paper",
     "preface",
     "preprint-article",
@@ -39,6 +37,9 @@ pub(crate) const DOCTYPES: [&str; 30] = [
     "table-of-contents",
     "textbook",
     "working-paper",
+    // --snip--
+    "other",
+    "none",
 ];
 
 #[derive(


### PR DESCRIPTION
## Summary

This PR changes the sort order of the `doctype` data type. All document types are sorted in lexicographical ascending order, except for the special variants `other` and `none`, which now always appear at the end.